### PR TITLE
Tokenization step updated,   Update 11_midlevel_data.ipynb

### DIFF
--- a/11_midlevel_data.ipynb
+++ b/11_midlevel_data.ipynb
@@ -153,9 +153,11 @@
     }
    ],
    "source": [
-    "tok = Tokenizer.from_folder(path)\n",
+    "spacy = WordTokenizer()\n",
+    "tok = Tokenizer(spacy)\n",
     "tok.setup(txts)\n",
     "toks = txts.map(tok)\n",
+    
     "toks[0]"
    ]
   },


### PR DESCRIPTION
The tokenization here can be processed because it is trying to read "counter.pkl" but by default there is not '/root/.fastai/data/imdb_tok/counter.pkl'.
So this step is updated as according to the one mentiond in previous chapter. 